### PR TITLE
Fix cart count in checkout success page

### DIFF
--- a/checkout_success.php
+++ b/checkout_success.php
@@ -89,7 +89,7 @@ if (!$order) {
             <h1>Glitch Mall</h1>
             <div class="nav-links">
                 <a href="index.php">首頁</a>
-                <a href="cart.php">購物車 (0)</a>
+                <a href="cart.php">購物車 (<?php echo count($_SESSION['cart'] ?? []); ?>)</a>
             </div>
         </nav>
     </header>


### PR DESCRIPTION
## Summary
- display current cart count in `checkout_success.php` navigation link

## Testing
- `php -l checkout_success.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684051b4b3d08326834538b230081c1f